### PR TITLE
Virtual reserves for quotes + improve log-parsing fn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1251,7 +1251,7 @@ checksum = "afb84c814227b90d6895e01398aee0d8033c00e7466aca416fb6a8e0eb19d8a7"
 [[package]]
 name = "clmm-cpi"
 version = "0.1.0"
-source = "git+https://github.com/GooseFX1/gamma-swap.git?rev=c4ca68e730a39a0d50ec3dc7994b5d765c29f631#c4ca68e730a39a0d50ec3dc7994b5d765c29f631"
+source = "git+https://github.com/GooseFX1/gamma-swap.git?branch=master#3315bade1aaa1389eec284acc8aaeb03e5e76d0a"
 dependencies = [
  "anchor-gen",
  "anchor-lang",
@@ -1355,7 +1355,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 [[package]]
 name = "cpmm-cpi"
 version = "0.1.0"
-source = "git+https://github.com/GooseFX1/gamma-swap.git?rev=c4ca68e730a39a0d50ec3dc7994b5d765c29f631#c4ca68e730a39a0d50ec3dc7994b5d765c29f631"
+source = "git+https://github.com/GooseFX1/gamma-swap.git?branch=master#3315bade1aaa1389eec284acc8aaeb03e5e76d0a"
 dependencies = [
  "anchor-gen",
  "anchor-lang",
@@ -1694,7 +1694,7 @@ dependencies = [
 [[package]]
 name = "dlmm-cpi"
 version = "0.1.0"
-source = "git+https://github.com/GooseFX1/gamma-swap.git?rev=c4ca68e730a39a0d50ec3dc7994b5d765c29f631#c4ca68e730a39a0d50ec3dc7994b5d765c29f631"
+source = "git+https://github.com/GooseFX1/gamma-swap.git?branch=master#3315bade1aaa1389eec284acc8aaeb03e5e76d0a"
 dependencies = [
  "anchor-gen",
  "anchor-lang",
@@ -2026,7 +2026,7 @@ dependencies = [
 [[package]]
 name = "gamma"
 version = "0.1.0"
-source = "git+https://github.com/GooseFX1/gamma-swap.git?rev=c4ca68e730a39a0d50ec3dc7994b5d765c29f631#c4ca68e730a39a0d50ec3dc7994b5d765c29f631"
+source = "git+https://github.com/GooseFX1/gamma-swap.git?branch=master#3315bade1aaa1389eec284acc8aaeb03e5e76d0a"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
@@ -6477,7 +6477,7 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 [[package]]
 name = "whirlpool-cpi"
 version = "0.1.0"
-source = "git+https://github.com/GooseFX1/gamma-swap.git?rev=c4ca68e730a39a0d50ec3dc7994b5d765c29f631#c4ca68e730a39a0d50ec3dc7994b5d765c29f631"
+source = "git+https://github.com/GooseFX1/gamma-swap.git?branch=master#3315bade1aaa1389eec284acc8aaeb03e5e76d0a"
 dependencies = [
  "anchor-gen",
  "anchor-lang",
@@ -6505,7 +6505,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ csv = "1.3.1"
 dotenv = "0.15.0"
 env_logger = "0.11.5"
 jupiter-swap-api-client = { git = "https://github.com/jup-ag/jupiter-swap-api-client.git", branch = "release/0.1.0" }
-gamma = { git = "https://github.com/GooseFX1/gamma-swap.git", rev = "c4ca68e730a39a0d50ec3dc7994b5d765c29f631" }
+gamma = { git = "https://github.com/GooseFX1/gamma-swap.git", branch = "master" }
 hex = "0.4.3"
 log = "0.4.22"
 regex = "1.11.1"

--- a/src/bin/swap_test_csv.rs
+++ b/src/bin/swap_test_csv.rs
@@ -211,7 +211,8 @@ pub async fn main() -> anyhow::Result<()> {
 
         // Decode transaction logs to get SwapInfo and SwapEvent
         let swap_event = match decode_transaction_logs(&rpc_client, &signature).await {
-            Ok(event) => event,
+            Ok(Some(event)) => event,
+            Ok(None) => continue,
             Err(e) => {
                 log::error!("Failed to decode transaction logs: {}", e);
                 continue; // Skip to the next iteration

--- a/src/gfx_swap/quote.rs
+++ b/src/gfx_swap/quote.rs
@@ -98,10 +98,7 @@ impl GfxSwapClient {
         log::debug!("Pool: {}", pool);
         log::debug!("Token0 vault amount: {}", token_0_vault_info.base.amount);
         log::debug!("Token1 vault amount: {}", token_1_vault_info.base.amount);
-        let (total_token_0_amount, total_token_1_amount) = pool_state.vault_amount_without_fee(
-            token_0_vault_info.base.amount,
-            token_1_vault_info.base.amount,
-        )?;
+        let (total_token_0_amount, total_token_1_amount) = pool_state.vault_amount_without_fee()?;
 
         let (
             _trade_direction,

--- a/src/tx_utils/decode_logs.rs
+++ b/src/tx_utils/decode_logs.rs
@@ -7,7 +7,7 @@ use solana_transaction_status::UiTransactionEncoding;
 pub async fn decode_transaction_logs(
     rpc_client: &RpcClient,
     signature: &Signature,
-) -> anyhow::Result<SwapEvent> {
+) -> anyhow::Result<Option<SwapEvent>> {
     let tx = rpc_client
         .get_transaction_with_config(
             signature,
@@ -33,23 +33,9 @@ pub async fn decode_transaction_logs(
         encoded_transaction,
         meta.clone(),
     )?;
-    let mut swap_event: SwapEvent = SwapEvent {
-        pool_id: Pubkey::default(),
-        input_vault_before: 0,
-        output_vault_before: 0,
-        input_amount: 0,
-        output_amount: 0,
-        input_transfer_fee: 0,
-        output_transfer_fee: 0,
-        base_input: false,
-        dynamic_fee: 0,
-    };
     // decode logs
     parse_program_event(
         gamma::id().to_string().as_str(),
         meta.clone(),
-        &mut swap_event,
-    )?;
-
-    Ok(swap_event)
+    ).map_err(Into::into)
 }

--- a/src/tx_utils/events_instructions_parse.rs
+++ b/src/tx_utils/events_instructions_parse.rs
@@ -20,8 +20,7 @@ pub enum InstructionDecodeType {
 pub fn parse_program_event(
     self_program_str: &str,
     meta: Option<UiTransactionStatusMeta>,
-    swap_event_emitted: &mut SwapEvent,
-) -> Result<(), ClientError> {
+) -> Result<Option<SwapEvent>, ClientError> {
     let logs: Vec<String> = if let Some(meta_data) = meta {
         let log_messages = if let OptionSerializer::Some(log_messages) = meta_data.log_messages {
             log_messages
@@ -48,7 +47,7 @@ pub fn parse_program_event(
                     };
                 match swap_event {
                     Some(swap_event) => {
-                        *swap_event_emitted = swap_event;
+                        return Ok(Some(swap_event))
                     }
                     _ => {}
                 }
@@ -65,7 +64,7 @@ pub fn parse_program_event(
     } else {
         println!("log is empty");
     }
-    Ok(())
+    Ok(None)
 }
 
 struct Execution {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -20,6 +20,7 @@ pub fn derive_pool_pda(
     )
 }
 
+#[allow(unused)]
 pub fn derive_vault_pda(pool: &Pubkey, mint: &Pubkey, program_id: &Pubkey) -> (Pubkey, u8) {
     Pubkey::find_program_address(
         &[POOL_VAULT_SEED.as_bytes(), pool.as_ref(), mint.as_ref()],
@@ -44,7 +45,7 @@ pub fn get_keys_for_pool_exclusive(
         data.token_0_mint,
         data.token_1_mint,
         derive_observation_pda(pool, program_id).0,
-        derive_vault_pda(pool, &data.token_0_mint, program_id).0,
-        derive_vault_pda(pool, &data.token_1_mint, program_id).0,
+        // derive_vault_pda(pool, &data.token_0_mint, program_id).0,
+        // derive_vault_pda(pool, &data.token_1_mint, program_id).0,
     ]
 }


### PR DESCRIPTION
This PR mainly does two things:
- Updates the `parse_program_event` function. Instead of taking a mutable reference to a `SwapEvent` and modifying it, the return type is changed to a `Result<Option<SwapEvent>>` and the event is constructed internally and returned if it can be parsed from the logs
- Updates the gamma dependency and quoting logic. Removes streaming vault-account updates since they're not used for quotes